### PR TITLE
Create GitHub Pages All Badges.md

### DIFF
--- a/Documenti/Documenti ufficiali/GitHub Pages All Badges.md
+++ b/Documenti/Documenti ufficiali/GitHub Pages All Badges.md
@@ -1,0 +1,37 @@
+## MagicMirror-GBM
+
+_Under construction..._
+
+Badge _(TUTTI i necessari inclusi. Necessario riordine!)_:
+
+![Dependecies from david-dm.org](https://status.david-dm.org/gh/AndreaGrandieri/MagicMirror-GBM.svg)
+
+![GitHub Issues from shields.io](https://img.shields.io/github/issues/AndreaGrandieri/MagicMirror-GBM)
+
+![GitHub PR from shields.io](https://img.shields.io/github/issues-pr/AndreaGrandieri/MagicMirror-GBM)
+
+![GitHub Forks from shields.io](https://img.shields.io/github/forks/AndreaGrandieri/MagicMirror-GBM)
+
+![GitHub Stars from shields.io](https://img.shields.io/github/stars/AndreaGrandieri/MagicMirror-GBM)
+
+![GitHub License from shields.io](https://img.shields.io/github/license/AndreaGrandieri/MagicMirror-GBM)
+
+![GitHub Vulnerabilities from snyk.io](https://snyk.io/test/github/AndreaGrandieri/MagicMirror-GBM/badge.svg)
+
+![GitHub Top Language from shields.io](https://img.shields.io/github/languages/top/AndreaGrandieri/MagicMirror-GBM)
+
+![GitHub Code Size from shields.io](https://img.shields.io/github/languages/code-size/AndreaGrandieri/MagicMirror-GBM)
+
+![GitHub Releases Download Count from shields.io](https://img.shields.io/github/downloads/AndreaGrandieri/MagicMirror-GBM/total)
+
+![GitHub Active Milestone from shields.io](https://img.shields.io/github/milestones/open/AndreaGrandieri/MagicMirror-GBM)
+
+![GitHUb User AndreaGrandieri Follow from shields.io](https://img.shields.io/github/followers/AndreaGrandieri?label=Follow&style=social)
+
+![GitHub Repo Fork from shields.io](https://img.shields.io/github/forks/AndreaGrandieri/MagicMirror-GBM?label=Fork&style=social)
+
+![GitHub Repo Star from shields.io](https://img.shields.io/github/stars/AndreaGrandieri/MagicMirror-GBM?style=social)
+
+![GitHub Releases and Pre from shields.io](https://img.shields.io/github/v/release/AndreaGrandieri/MagicMirror-GBM?include_prereleases)
+
+![GitHub M Commit Activity from shields.io](https://img.shields.io/github/commit-activity/m/AndreaGrandieri/MagicMirror-GBM)


### PR DESCRIPTION
Creata pagina di backup della situazione della pagina di GitHub Pages con la presenza di tutti i badge